### PR TITLE
Allow multiple values for literate-elisp-*-src-id, other fixes

### DIFF
--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -135,17 +135,20 @@ Argument IN: input stream."
   "Fix read error `invalid-read-syntax'.
 Argument IN: input stream.
 Argument BODY: body codes."
-  `(condition-case ex
-        ,@body
-      (invalid-read-syntax
-       (when literate-elisp-debug-p
-         (message "reach invalid read syntax %s at position %s"
-                  ex (literate-elisp-position in)))
-       (if (equal "#" (second ex))
-         ;; maybe this is #+end_src
-         (literate-elisp-read-after-sharpsign in)
-         ;; re-throw this signal because we don't know how to handle it.
-         (signal (car ex) (cdr err))))))
+  (declare (indent 1)
+           (debug ([&or bufferp markerp symbolp stringp "t"] body)))
+  (let ((ex (gensym)))
+    `(condition-case ,ex
+         ,@body
+       (invalid-read-syntax
+        (when literate-elisp-debug-p
+          (message "reach invalid read syntax %s at position %s"
+                   ,ex (literate-elisp-position in)))
+        (if (equal "#" (second ,ex))
+            ;; maybe this is #+end_src
+            (literate-elisp-read-after-sharpsign in)
+          ;; re-throw this signal because we don't know how to handle it.
+          (signal (car ,ex) (cdr ,ex)))))))
 
 (defun literate-elisp-ignore-white-space (in)
   "Skip white space characters.

--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -154,6 +154,32 @@ Argument IN: input stream."
     ;; discard current character.
     (literate-elisp-next in)))
 
+(defmacro literate-elisp-src-ids-loop (id-or-ids &rest body)
+  "Iterate BODY with each value of ID-OR-IDS bound to ‘id’.
+ID-OR-IDS can be a single value or a list.
+
+If any iteration returns non-nil, iteration stops and the non-nil
+value is returned. Otherwise, returns nil.
+
+Each iteration will run with point at its original position.
+Whichever iteration moves point the farthest will determine where
+point will be at the end of the loop."
+  (declare (indent 1)
+           (debug (form body)))
+  (let ((ids (gensym))
+        (start (gensym))
+        (end (gensym))
+        (result (gensym)))
+    `(cl-loop with ,ids = (if (listp ,id-or-ids) ,id-or-ids (list ,id-or-ids))
+              and ,start = (point)
+              and ,end = (point)
+              and ,result
+              for id in ,ids
+              do (goto-char ,start)
+              (setq ,result (progn ,@body))
+              (goto-char (setq ,end (max ,end (point))))
+              thereis ,result)))
+
 (defvar literate-elisp-read (symbol-function 'read))
 
 (defun literate-elisp-read-datum (in)

--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -158,30 +158,28 @@ Argument IN: input stream."
     (literate-elisp-next in)))
 
 (defmacro literate-elisp-src-ids-loop (id-or-ids &rest body)
-  "Iterate BODY with each value of ID-OR-IDS bound to ‘id’.
+  "Iterate BODY with each value of ID-OR-IDS bound to `id'.
 ID-OR-IDS can be a single value or a list.
 
 If any iteration returns non-nil, iteration stops and the non-nil
 value is returned. Otherwise, returns nil.
 
-Each iteration will run with point at its original position.
-Whichever iteration moves point the farthest will determine where
-point will be at the end of the loop."
+Only a successful iteration (one which returns non-nil) will be
+able to move point."
   (declare (indent 1)
            (debug (form body)))
   (let ((ids (cl-gensym))
         (start (cl-gensym))
-        (end (cl-gensym))
         (result (cl-gensym)))
     `(cl-loop with ,ids = (if (listp ,id-or-ids) ,id-or-ids (list ,id-or-ids))
               and ,start = (point)
-              and ,end = (point)
               and ,result
               for id in ,ids
-              do (goto-char ,start)
-              (setq ,result (progn ,@body))
-              (goto-char (setq ,end (max ,end (point))))
-              thereis ,result)))
+              do (setq ,result (progn ,@body))
+              if ,result
+                return ,result
+              else
+                do (goto-char ,start))))
 
 (defvar literate-elisp-read (symbol-function 'read))
 

--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -36,7 +36,6 @@
 
 
 (require 'cl-lib)
-(eval-when-compile (require 'subr-x))
 
 (defvar literate-elisp-debug-p nil)
 
@@ -244,18 +243,18 @@ Argument IN: input stream."
            (cl-case c
              ;; check if it is ~#+~, which has only legal meaning when it is equal `#+end_src'
              (?\+
-              (if-let ((line (literate-elisp-read-until-end-of-line in))
-                       ((literate-elisp-src-ids-loop literate-elisp-end-src-id
-                          (string-prefix-p (substring id 2) line t))))
-                  (progn
-                    (when literate-elisp-debug-p
-                      (message "found org elisp end block:%s" line))
-                    ;; if it is `#+end_src', then switch to org mode syntax.
-                    (setf literate-elisp-org-code-blocks-p nil))
-                ;; if it is ~#+~ followed by something other than ~end_src~, raise an error
-                (error "Unknown syntax on line %d: #+%s" (line-number-at-pos) line)))
-             ;; if it is not ~#+~, then use original elisp reader to read the following stream
-             (t (funcall literate-elisp-read in)))))))
+              (let ((line (literate-elisp-read-until-end-of-line in)))
+                (if (literate-elisp-src-ids-loop literate-elisp-end-src-id
+                      (string-prefix-p (substring id 2) line t))
+                    (progn
+                      (when literate-elisp-debug-p
+                        (message "found org elisp end block:%s" line))
+                      ;; if it is `#+end_src', then switch to org mode syntax.
+                      (setf literate-elisp-org-code-blocks-p nil))
+                  ;; if it is ~#+~ followed by something other than ~end_src~, raise an error
+                  (error "Unknown syntax on line %d: #+%s" (line-number-at-pos) line))))
+              ;; if it is not ~#+~, then use original elisp reader to read the following stream
+              (t (funcall literate-elisp-read in)))))))
 
 (defun literate-elisp-read-internal (&optional in)
   "A wrapper to follow the behavior of original read function.

--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -41,7 +41,7 @@
 
 (defvar literate-elisp-org-code-blocks-p nil)
 
-(defvar literate-elisp-begin-src-id "#+BEGIN_SRC elisp")
+(defvar literate-elisp-begin-src-id '("#+BEGIN_SRC elisp" "#+BEGIN_SRC emacs-lisp"))
 (defvar literate-elisp-end-src-id "#+END_SRC")
 
 (defun literate-elisp-peek (in)

--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -355,11 +355,13 @@ Argument BUF: source buffer."
                (write-char ?\n)
                (forward-line 1)))))
 
-(cl-defun literate-elisp-tangle (file &key (el-file (concat (file-name-sans-extension file) ".el"))
+(cl-defun literate-elisp-tangle (&optional (file (or org-src-source-file-name (buffer-file-name)))
+                                 &key (el-file (concat (file-name-sans-extension file) ".el"))
                                 header tail
                                 test-p)
   "Literate tangle
 Argument FILE: target file"
+  (interactive)
   (let* ((source-buffer (find-file-noselect file))
          (target-buffer (find-file-noselect el-file))
          (org-path-name (concat (file-name-base file) "." (file-name-extension file)))
@@ -378,12 +380,13 @@ Argument FILE: target file"
               "\n"))
 
     (with-current-buffer source-buffer
-      (goto-char (point-min))
-      (cl-loop for obj = (literate-elisp-read-internal source-buffer)
-               if obj
-               do (with-current-buffer target-buffer
-                    (insert obj "\n"))
-               until (eobp)))
+      (save-excursion
+        (goto-char (point-min))
+        (cl-loop for obj = (literate-elisp-read-internal source-buffer)
+                 if obj
+                 do (with-current-buffer target-buffer
+                      (insert obj "\n"))
+                 until (eobp))))
 
     (with-current-buffer target-buffer
       (when tail

--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -157,29 +157,29 @@ Argument IN: input stream."
     ;; discard current character.
     (literate-elisp-next in)))
 
-(defmacro literate-elisp-src-ids-loop (id-or-ids &rest body)
+(defmacro literate-elisp-src-ids-loop (id-or-ids buf &rest body)
   "Iterate BODY with each value of ID-OR-IDS bound to `id'.
-ID-OR-IDS can be a single value or a list.
+ID-OR-IDS can be a single value or a list. BUF is the relevant
+source buffer. If nil, BUF will default to the current buffer.
 
 If any iteration returns non-nil, iteration stops and the non-nil
 value is returned. Otherwise, returns nil.
 
 Only a successful iteration (one which returns non-nil) will be
-able to move point."
-  (declare (indent 1)
+able to move point in the source buffer."
+  (declare (indent 2)
            (debug (form body)))
   (let ((ids (cl-gensym))
         (start (cl-gensym))
-        (result (cl-gensym)))
+        (buffer (cl-gensym)))
     `(cl-loop with ,ids = (if (listp ,id-or-ids) ,id-or-ids (list ,id-or-ids))
-              and ,start = (point)
-              and ,result
+              with ,buffer = (or ,buf (current-buffer))
+              with ,start = (with-current-buffer ,buffer (point))
               for id in ,ids
-              do (setq ,result (progn ,@body))
-              if ,result
-                return ,result
+              if (progn ,@body)
+                return it
               else
-                do (goto-char ,start))))
+                do (with-current-buffer ,buffer (goto-char ,start)))))
 
 (defvar literate-elisp-read (symbol-function 'read))
 
@@ -214,7 +214,7 @@ Argument IN: input stream."
   ;;     if it is not inside an elisp syntax
   (cond ((not literate-elisp-org-code-blocks-p)
          ;; check if it is `#+begin_src elisp'
-         (if (literate-elisp-src-ids-loop literate-elisp-begin-src-id
+         (if (literate-elisp-src-ids-loop literate-elisp-begin-src-id in
                (cl-loop for i from 1 below (length id)
                         for c1 = (aref id i)
                         for c2 = (literate-elisp-next in)
@@ -242,7 +242,7 @@ Argument IN: input stream."
              ;; check if it is ~#+~, which has only legal meaning when it is equal `#+end_src'
              (?\+
               (let ((line (literate-elisp-read-until-end-of-line in)))
-                (if (literate-elisp-src-ids-loop literate-elisp-end-src-id
+                (if (literate-elisp-src-ids-loop literate-elisp-end-src-id in
                       (string-prefix-p (substring id 2) line t))
                     (progn
                       (when literate-elisp-debug-p
@@ -344,7 +344,7 @@ Argument BUF: source buffer."
 
       (cl-loop for line = (buffer-substring-no-properties (line-beginning-position) (line-end-position))
                until (or (eobp)
-                         (literate-elisp-src-ids-loop literate-elisp-end-src-id
+                         (literate-elisp-src-ids-loop literate-elisp-end-src-id buf
                            (string-equal (string-trim (downcase line)) (downcase id))))
                do (loop for c across line
                         do (write-char c))

--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -36,6 +36,7 @@
 
 
 (require 'cl-lib)
+(eval-when-compile (require 'subr-x))
 
 (defvar literate-elisp-debug-p nil)
 

--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -240,13 +240,17 @@ Argument IN: input stream."
            (cl-case c
              ;; check if it is ~#+~, which has only legal meaning when it is equal `#+end_src'
              (?\+
-              (let ((line (literate-elisp-read-until-end-of-line in)))
-                (when literate-elisp-debug-p
-                  (message "found org elisp end block:%s" line)))
-             ;; if it is, then switch to org mode syntax.
-              (setf literate-elisp-org-code-blocks-p nil)
-              nil)
-             ;; if it is not, then use original elip reader to read the following stream
+              (if-let ((line (literate-elisp-read-until-end-of-line in))
+                       ((literate-elisp-src-ids-loop literate-elisp-end-src-id
+                          (string-prefix-p (substring id 2) line t))))
+                  (progn
+                    (when literate-elisp-debug-p
+                      (message "found org elisp end block:%s" line))
+                    ;; if it is `#+end_src', then switch to org mode syntax.
+                    (setf literate-elisp-org-code-blocks-p nil))
+                ;; if it is ~#+~ followed by something other than ~end_src~, raise an error
+                (error "Unknown syntax on line %d: #+%s" (line-number-at-pos) line)))
+             ;; if it is not ~#+~, then use original elisp reader to read the following stream
              (t (funcall literate-elisp-read in)))))))
 
 (defun literate-elisp-read-internal (&optional in)
@@ -329,22 +333,24 @@ Arguemnt ARGS: the arguments to original advice function."
 
 (defun literate-elisp-tangle-reader (&optional buf)
   "Tangling codes in one code block.
-Arguemnt BUF: source buffer."
+Argument BUF: source buffer."
   (with-output-to-string
-      (with-current-buffer buf
-        (when (/= (point) (line-beginning-position))
-          ;; if reader still in last line,move it to next line.
-          (forward-line 1))
+    (with-current-buffer buf
+      (when (not (string-blank-p
+                  (buffer-substring (line-beginning-position) (point))))
+        ;; if reader still in last line,move it to next line.
+        (forward-line 1))
 
-        (loop for line = (buffer-substring-no-properties (line-beginning-position) (line-end-position))
-              until (or (eobp)
-                        (string-equal (trim-string (downcase line)) "#+end_src"))
-              do (loop for c across line
-                       do (write-char c))
-                 (when literate-elisp-debug-p
-                   (message "tangle elisp line %s" line))
-                 (write-char ?\n)
-                 (forward-line 1)))))
+      (cl-loop for line = (buffer-substring-no-properties (line-beginning-position) (line-end-position))
+               until (or (eobp)
+                         (literate-elisp-src-ids-loop literate-elisp-end-src-id
+                           (string-equal (string-trim (downcase line)) (downcase id))))
+               do (loop for c across line
+                        do (write-char c))
+               (when literate-elisp-debug-p
+                 (message "tangle elisp line %s" line))
+               (write-char ?\n)
+               (forward-line 1)))))
 
 (cl-defun literate-elisp-tangle (file &key (el-file (concat (file-name-sans-extension file) ".el"))
                                 header tail

--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -138,7 +138,7 @@ Argument IN: input stream.
 Argument BODY: body codes."
   (declare (indent 1)
            (debug ([&or bufferp markerp symbolp stringp "t"] body)))
-  (let ((ex (gensym)))
+  (let ((ex (cl-gensym)))
     `(condition-case ,ex
          ,@body
        (invalid-read-syntax
@@ -170,10 +170,10 @@ Whichever iteration moves point the farthest will determine where
 point will be at the end of the loop."
   (declare (indent 1)
            (debug (form body)))
-  (let ((ids (gensym))
-        (start (gensym))
-        (end (gensym))
-        (result (gensym)))
+  (let ((ids (cl-gensym))
+        (start (cl-gensym))
+        (end (cl-gensym))
+        (result (cl-gensym)))
     `(cl-loop with ,ids = (if (listp ,id-or-ids) ,id-or-ids (list ,id-or-ids))
               and ,start = (point)
               and ,end = (point)

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -386,13 +386,17 @@ Argument IN: input stream."
            (cl-case c
              ;; check if it is ~#+~, which has only legal meaning when it is equal `#+end_src'
              (?\+
-              (let ((line (literate-elisp-read-until-end-of-line in)))
-                (when literate-elisp-debug-p
-                  (message "found org elisp end block:%s" line)))
-             ;; if it is, then switch to org mode syntax.
-              (setf literate-elisp-org-code-blocks-p nil)
-              nil)
-             ;; if it is not, then use original elip reader to read the following stream
+              (if-let ((line (literate-elisp-read-until-end-of-line in))
+                       ((literate-elisp-src-ids-loop literate-elisp-end-src-id
+                          (string-prefix-p (substring id 2) line t))))
+                  (progn
+                    (when literate-elisp-debug-p
+                      (message "found org elisp end block:%s" line))
+                    ;; if it is `#+end_src', then switch to org mode syntax.
+                    (setf literate-elisp-org-code-blocks-p nil))
+                ;; if it is ~#+~ followed by something other than ~end_src~, raise an error
+                (error "Unknown syntax on line %d: #+%s" (line-number-at-pos) line)))
+             ;; if it is not ~#+~, then use original elisp reader to read the following stream
              (t (funcall literate-elisp-read in)))))))
 #+END_SRC
 ** load/compile org file with new syntax
@@ -519,22 +523,24 @@ label:literate-elisp-tangle-reader
 #+BEGIN_SRC elisp
 (defun literate-elisp-tangle-reader (&optional buf)
   "Tangling codes in one code block.
-Arguemnt BUF: source buffer."
+Argument BUF: source buffer."
   (with-output-to-string
-      (with-current-buffer buf
-        (when (/= (point) (line-beginning-position))
-          ;; if reader still in last line,move it to next line.
-          (forward-line 1))
+    (with-current-buffer buf
+      (when (not (string-blank-p
+                  (buffer-substring (line-beginning-position) (point))))
+        ;; if reader still in last line,move it to next line.
+        (forward-line 1))
 
-        (loop for line = (buffer-substring-no-properties (line-beginning-position) (line-end-position))
-              until (or (eobp)
-                        (string-equal (trim-string (downcase line)) "#+end_src"))
-              do (loop for c across line
-                       do (write-char c))
-                 (when literate-elisp-debug-p
-                   (message "tangle elisp line %s" line))
-                 (write-char ?\n)
-                 (forward-line 1)))))
+      (cl-loop for line = (buffer-substring-no-properties (line-beginning-position) (line-end-position))
+               until (or (eobp)
+                         (literate-elisp-src-ids-loop literate-elisp-end-src-id
+                           (string-equal (string-trim (downcase line)) (downcase id))))
+               do (loop for c across line
+                        do (write-char c))
+               (when literate-elisp-debug-p
+                 (message "tangle elisp line %s" line))
+               (write-char ?\n)
+               (forward-line 1)))))
 #+END_SRC
 
 Now we can tangle the elisp code blocks with the following codes.

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -237,17 +237,20 @@ Please note that the stream position is just after the character ~#~ when above 
   "Fix read error `invalid-read-syntax'.
 Argument IN: input stream.
 Argument BODY: body codes."
-  `(condition-case ex
-        ,@body
-      (invalid-read-syntax
-       (when literate-elisp-debug-p
-         (message "reach invalid read syntax %s at position %s"
-                  ex (literate-elisp-position in)))
-       (if (equal "#" (second ex))
-         ;; maybe this is #+end_src
-         (literate-elisp-read-after-sharpsign in)
-         ;; re-throw this signal because we don't know how to handle it.
-         (signal (car ex) (cdr err))))))
+  (declare (indent 1)
+           (debug ([&or bufferp markerp symbolp stringp "t"] body)))
+  (let ((ex (gensym)))
+    `(condition-case ,ex
+         ,@body
+       (invalid-read-syntax
+        (when literate-elisp-debug-p
+          (message "reach invalid read syntax %s at position %s"
+                   ,ex (literate-elisp-position in)))
+        (if (equal "#" (second ,ex))
+            ;; maybe this is #+end_src
+            (literate-elisp-read-after-sharpsign in)
+          ;; re-throw this signal because we don't know how to handle it.
+          (signal (car ,ex) (cdr ,ex)))))))
 #+END_SRC
 
 *** handle prefix spaces.

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -83,7 +83,7 @@ It'll indicate whether org mode syntax or elisp mode syntax is in use.
 
 And the code block begin/end identifies:
 #+BEGIN_SRC elisp
-(defvar literate-elisp-begin-src-id "#+BEGIN_SRC elisp")
+(defvar literate-elisp-begin-src-id '("#+BEGIN_SRC elisp" "#+BEGIN_SRC emacs-lisp"))
 (defvar literate-elisp-end-src-id "#+END_SRC")
 #+END_SRC
 

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -278,34 +278,35 @@ Code that would otherwise be written this way:
 #+END_EXAMPLE
 …can instead be written like this:
 #+BEGIN_EXAMPLE elisp
-(literate-elisp-src-ids-loop literate-elisp-begin-src-id
+(literate-elisp-src-ids-loop literate-elisp-begin-src-id BUFFER
   (string-equal id string-var))
 #+END_EXAMPLE
+…with ~BUFFER~ replaced with the current source buffer (or nil, to use the current buffer).
 If ~literate-elisp-begin-src-id~ is a single string, the two examples will work identically; when it is a list, then the second example will loop over the macro body, with ‘id’ bound to each element of ~literate-elisp-begin-src-id~, and will return t if any iteration returns t.
 #+BEGIN_SRC elisp
-(defmacro literate-elisp-src-ids-loop (id-or-ids &rest body)
+(defmacro literate-elisp-src-ids-loop (id-or-ids buf &rest body)
   "Iterate BODY with each value of ID-OR-IDS bound to `id'.
-ID-OR-IDS can be a single value or a list.
+ID-OR-IDS can be a single value or a list. BUF is the relevant
+source buffer. If nil, BUF will default to the current buffer.
 
 If any iteration returns non-nil, iteration stops and the non-nil
 value is returned. Otherwise, returns nil.
 
 Only a successful iteration (one which returns non-nil) will be
-able to move point."
-  (declare (indent 1)
+able to move point in the source buffer."
+  (declare (indent 2)
            (debug (form body)))
   (let ((ids (cl-gensym))
         (start (cl-gensym))
-        (result (cl-gensym)))
+        (buffer (cl-gensym)))
     `(cl-loop with ,ids = (if (listp ,id-or-ids) ,id-or-ids (list ,id-or-ids))
-              and ,start = (point)
-              and ,result
+              with ,buffer = (or ,buf (current-buffer))
+              with ,start = (with-current-buffer ,buffer (point))
               for id in ,ids
-              do (setq ,result (progn ,@body))
-              if ,result
-                return ,result
+              if (progn ,@body)
+                return it
               else
-                do (goto-char ,start))))
+                do (with-current-buffer ,buffer (goto-char ,start)))))
 #+END_SRC
 
 *** alternative elisp read function
@@ -362,7 +363,7 @@ Argument IN: input stream."
   ;;     if it is not inside an elisp syntax
   (cond ((not literate-elisp-org-code-blocks-p)
          ;; check if it is `#+begin_src elisp'
-         (if (literate-elisp-src-ids-loop literate-elisp-begin-src-id
+         (if (literate-elisp-src-ids-loop literate-elisp-begin-src-id in
                (cl-loop for i from 1 below (length id)
                         for c1 = (aref id i)
                         for c2 = (literate-elisp-next in)
@@ -390,7 +391,7 @@ Argument IN: input stream."
              ;; check if it is ~#+~, which has only legal meaning when it is equal `#+end_src'
              (?\+
               (let ((line (literate-elisp-read-until-end-of-line in)))
-                (if (literate-elisp-src-ids-loop literate-elisp-end-src-id
+                (if (literate-elisp-src-ids-loop literate-elisp-end-src-id in
                       (string-prefix-p (substring id 2) line t))
                     (progn
                       (when literate-elisp-debug-p
@@ -536,7 +537,7 @@ Argument BUF: source buffer."
 
       (cl-loop for line = (buffer-substring-no-properties (line-beginning-position) (line-end-position))
                until (or (eobp)
-                         (literate-elisp-src-ids-loop literate-elisp-end-src-id
+                         (literate-elisp-src-ids-loop literate-elisp-end-src-id buf
                            (string-equal (string-trim (downcase line)) (downcase id))))
                do (loop for c across line
                         do (write-char c))

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -264,6 +264,47 @@ Argument IN: input stream."
     (literate-elisp-next in)))
 #+END_SRC
 
+*** handle multiple values for literate-elisp-*-src-id
+This is a macro to allow ~literate-elisp-begin-src-id~ and ~literate-elisp-end-src-id~ to be either a string or a list of strings.
+Code that would otherwise be written this way:
+#+BEGIN_EXAMPLE elisp
+(string-equal literate-elisp-begin-src-id
+              string-var)
+#+END_EXAMPLE
+…can instead be written like this:
+#+BEGIN_EXAMPLE elisp
+(literate-elisp-src-ids-loop literate-elisp-begin-src-id
+  (string-match-p id string-var))
+#+END_EXAMPLE
+If ~literate-elisp-begin-src-id~ is a single string, the two examples will work identically; when it is a list, then the second example will loop over the macro body, with ‘id’ bound to each element of ~literate-elisp-begin-src-id~, and will return t if any iteration returns t.
+#+BEGIN_SRC elisp
+(defmacro literate-elisp-src-ids-loop (id-or-ids &rest body)
+  "Iterate BODY with each value of ID-OR-IDS bound to ‘id’.
+ID-OR-IDS can be a single value or a list.
+
+If any iteration returns non-nil, iteration stops and the non-nil
+value is returned. Otherwise, returns nil.
+
+Each iteration will run with point at its original position.
+Whichever iteration moves point the farthest will determine where
+point will be at the end of the loop."
+  (declare (indent 1)
+           (debug (form body)))
+  (let ((ids (gensym))
+        (start (gensym))
+        (end (gensym))
+        (result (gensym)))
+    `(cl-loop with ,ids = (if (listp ,id-or-ids) ,id-or-ids (list ,id-or-ids))
+              and ,start = (point)
+              and ,end = (point)
+              and ,result
+              for id in ,ids
+              do (goto-char ,start)
+              (setq ,result (progn ,@body))
+              (goto-char (setq ,end (max ,end (point))))
+              thereis ,result)))
+#+END_SRC
+
 *** alternative elisp read function
 When tangling org file, we want to tangle elisp codes without changing them(but Emacs original ~read~ will),
 so let's define a variable to hold the actual elisp reader used by us 

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -67,10 +67,9 @@ as like the original Emacs lisp reader.
 * Implementation
 ** Preparation
 
-We use common lisp and subr-x macros in this library
+We use common lisp macros in this library
 #+BEGIN_SRC elisp
 (require 'cl-lib)
-(eval-when-compile (require 'subr-x))
 #+END_SRC
 
 There is a debug variable to switch on/off the log messages for this library.
@@ -392,18 +391,18 @@ Argument IN: input stream."
            (cl-case c
              ;; check if it is ~#+~, which has only legal meaning when it is equal `#+end_src'
              (?\+
-              (if-let ((line (literate-elisp-read-until-end-of-line in))
-                       ((literate-elisp-src-ids-loop literate-elisp-end-src-id
-                          (string-prefix-p (substring id 2) line t))))
-                  (progn
-                    (when literate-elisp-debug-p
-                      (message "found org elisp end block:%s" line))
-                    ;; if it is `#+end_src', then switch to org mode syntax.
-                    (setf literate-elisp-org-code-blocks-p nil))
-                ;; if it is ~#+~ followed by something other than ~end_src~, raise an error
-                (error "Unknown syntax on line %d: #+%s" (line-number-at-pos) line)))
-             ;; if it is not ~#+~, then use original elisp reader to read the following stream
-             (t (funcall literate-elisp-read in)))))))
+              (let ((line (literate-elisp-read-until-end-of-line in)))
+                (if (literate-elisp-src-ids-loop literate-elisp-end-src-id
+                      (string-prefix-p (substring id 2) line t))
+                    (progn
+                      (when literate-elisp-debug-p
+                        (message "found org elisp end block:%s" line))
+                      ;; if it is `#+end_src', then switch to org mode syntax.
+                      (setf literate-elisp-org-code-blocks-p nil))
+                  ;; if it is ~#+~ followed by something other than ~end_src~, raise an error
+                  (error "Unknown syntax on line %d: #+%s" (line-number-at-pos) line))))
+              ;; if it is not ~#+~, then use original elisp reader to read the following stream
+              (t (funcall literate-elisp-read in)))))))
 #+END_SRC
 ** load/compile org file with new syntax
 *** literate reader is in use when loading a org file

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -67,9 +67,10 @@ as like the original Emacs lisp reader.
 * Implementation
 ** Preparation
 
-We use common lisp macros in this library
+We use common lisp and subr-x macros in this library
 #+BEGIN_SRC elisp
 (require 'cl-lib)
+(eval-when-compile (require 'subr-x))
 #+END_SRC
 
 There is a debug variable to switch on/off the log messages for this library.

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -665,6 +665,33 @@ Let's write a test case for above code block.
   (should (equal literate-elisp-a-test-variable 10)))
 #+END_SRC
 
+*** test code block with lowercase block delimiters
+Some code blocks have ~#+begin_src elisp~ and ~#+end_src~ in lowercase; let's test whether ~literate-elisp~ can match it case-insensitively.
+#+begin_src elisp :load test
+(defvar literate-elisp-test-variable-2 20)
+#+end_src
+
+Let's write a test case for above code block.
+#+BEGIN_SRC elisp :load test
+(ert-deftest literate-elisp-read-lowercase-code-block ()
+  "A spec of code block with lowercase block delimiters."
+  (should (equal literate-elisp-test-variable-2 20)))
+#+END_SRC
+
+*** test code block with ~emacs-lisp~ instead of ~elisp~
+Some code blocks use ~emacs-lisp~ instead of the shortened ~elisp~ as the language specifier; let's test whether ~literate-elisp-src-ids-loop~ is matching it properly.
+#+BEGIN_SRC emacs-lisp :load test
+(defvar literate-elisp-test-variable-3 30)
+#+END_SRC
+
+Let's write a test case for above code block.
+#+BEGIN_SRC elisp :load test
+(ert-deftest literate-elisp-read-block-with-lang-emacs-lisp ()
+  "A spec of code block with the language specifier `emacs-lisp'
+instead of `elisp'."
+  (should (equal literate-elisp-test-variable-3 30)))
+#+END_SRC
+
 *** test literate-elisp-read-header-arguments
 label:test-literate-elisp-read-header-arguments
 #+BEGIN_SRC elisp :load test

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -242,7 +242,7 @@ Argument IN: input stream.
 Argument BODY: body codes."
   (declare (indent 1)
            (debug ([&or bufferp markerp symbolp stringp "t"] body)))
-  (let ((ex (gensym)))
+  (let ((ex (cl-gensym)))
     `(condition-case ,ex
          ,@body
        (invalid-read-syntax
@@ -296,10 +296,10 @@ Whichever iteration moves point the farthest will determine where
 point will be at the end of the loop."
   (declare (indent 1)
            (debug (form body)))
-  (let ((ids (gensym))
-        (start (gensym))
-        (end (gensym))
-        (result (gensym)))
+  (let ((ids (cl-gensym))
+        (start (cl-gensym))
+        (end (cl-gensym))
+        (result (cl-gensym)))
     `(cl-loop with ,ids = (if (listp ,id-or-ids) ,id-or-ids (list ,id-or-ids))
               and ,start = (point)
               and ,end = (point)

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -359,23 +359,25 @@ Argument IN: input stream."
   ;;     if it is not inside an elisp syntax
   (cond ((not literate-elisp-org-code-blocks-p)
          ;; check if it is `#+begin_src elisp'
-         (if (cl-loop for i from 1 below (length literate-elisp-begin-src-id)
-                      for c1 = (aref literate-elisp-begin-src-id i)
-                      for c2 = (literate-elisp-next in)
-                      thereis (not (char-equal c1 c2)))
+         (if (literate-elisp-src-ids-loop literate-elisp-begin-src-id
+               (cl-loop for i from 1 below (length id)
+                        for c1 = (aref id i)
+                        for c2 = (literate-elisp-next in)
+                        with case-fold-search = t
+                        always (char-equal c1 c2)))
+             ;; if it is, read source block header arguments for this code block and check if it should be loaded.
+             (cond ((literate-elisp-load-p (literate-elisp-get-load-option in))
+                    ;; if it should be loaded, switch to elisp syntax context
+                    (when literate-elisp-debug-p
+                      (message "enter into an elisp code block"))
+                    (setf literate-elisp-org-code-blocks-p t)
+                    nil)
+                   (t
+                    ;; if it should not be loaded, continue to use org syntax and ignore this line
+                    nil))
            ;; if it is not, continue to use org syntax and ignore this line
-           (progn (literate-elisp-read-until-end-of-line in)
-                  nil)
-           ;; if it is, read source block header arguments for this code block and check if it should be loaded.
-           (cond ((literate-elisp-load-p (literate-elisp-get-load-option in))
-                  ;; if it should be loaded, switch to elisp syntax context
-                  (when literate-elisp-debug-p
-                    (message "enter into a elisp code block"))
-                  (setf literate-elisp-org-code-blocks-p t)
-                  nil)
-                 (t
-                  ;; if it should not be loaded, continue to use org syntax and ignore this line
-                 nil))))
+           (literate-elisp-read-until-end-of-line in)
+           nil))
         (t
         ;; 2. if it is inside an elisp syntax
          (let ((c (literate-elisp-next in)))

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -548,11 +548,13 @@ Argument BUF: source buffer."
 
 Now we can tangle the elisp code blocks with the following codes.
 #+BEGIN_SRC elisp
-(cl-defun literate-elisp-tangle (file &key (el-file (concat (file-name-sans-extension file) ".el"))
+(cl-defun literate-elisp-tangle (&optional (file (or org-src-source-file-name (buffer-file-name)))
+                                 &key (el-file (concat (file-name-sans-extension file) ".el"))
                                 header tail
                                 test-p)
   "Literate tangle
 Argument FILE: target file"
+  (interactive)
   (let* ((source-buffer (find-file-noselect file))
          (target-buffer (find-file-noselect el-file))
          (org-path-name (concat (file-name-base file) "." (file-name-extension file)))
@@ -571,12 +573,13 @@ Argument FILE: target file"
               "\n"))
 
     (with-current-buffer source-buffer
-      (goto-char (point-min))
-      (cl-loop for obj = (literate-elisp-read-internal source-buffer)
-               if obj
-               do (with-current-buffer target-buffer
-                    (insert obj "\n"))
-               until (eobp)))
+      (save-excursion
+        (goto-char (point-min))
+        (cl-loop for obj = (literate-elisp-read-internal source-buffer)
+                 if obj
+                 do (with-current-buffer target-buffer
+                      (insert obj "\n"))
+                 until (eobp))))
 
     (with-current-buffer target-buffer
       (when tail

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -279,35 +279,33 @@ Code that would otherwise be written this way:
 …can instead be written like this:
 #+BEGIN_EXAMPLE elisp
 (literate-elisp-src-ids-loop literate-elisp-begin-src-id
-  (string-match-p id string-var))
+  (string-equal id string-var))
 #+END_EXAMPLE
 If ~literate-elisp-begin-src-id~ is a single string, the two examples will work identically; when it is a list, then the second example will loop over the macro body, with ‘id’ bound to each element of ~literate-elisp-begin-src-id~, and will return t if any iteration returns t.
 #+BEGIN_SRC elisp
 (defmacro literate-elisp-src-ids-loop (id-or-ids &rest body)
-  "Iterate BODY with each value of ID-OR-IDS bound to ‘id’.
+  "Iterate BODY with each value of ID-OR-IDS bound to `id'.
 ID-OR-IDS can be a single value or a list.
 
 If any iteration returns non-nil, iteration stops and the non-nil
 value is returned. Otherwise, returns nil.
 
-Each iteration will run with point at its original position.
-Whichever iteration moves point the farthest will determine where
-point will be at the end of the loop."
+Only a successful iteration (one which returns non-nil) will be
+able to move point."
   (declare (indent 1)
            (debug (form body)))
   (let ((ids (cl-gensym))
         (start (cl-gensym))
-        (end (cl-gensym))
         (result (cl-gensym)))
     `(cl-loop with ,ids = (if (listp ,id-or-ids) ,id-or-ids (list ,id-or-ids))
               and ,start = (point)
-              and ,end = (point)
               and ,result
               for id in ,ids
-              do (goto-char ,start)
-              (setq ,result (progn ,@body))
-              (goto-char (setq ,end (max ,end (point))))
-              thereis ,result)))
+              do (setq ,result (progn ,@body))
+              if ,result
+                return ,result
+              else
+                do (goto-char ,start))))
 #+END_SRC
 
 *** alternative elisp read function

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -1,4 +1,4 @@
-# -*- encoding:utf-8 Mode: POLY-ORG;  -*- --- 
+# -*- encoding:utf-8 Mode: POLY-ORG; org-src-preserve-indentation: t; -*- --- 
 #+TITLE:  elisp literate library
 #+SubTitle: a literate programming tool to write Emacs lisp codes in org mode.
 #+OPTIONS: toc:2
@@ -6,6 +6,8 @@
 #+LATEX_HEADER: % copied from lstlang1.sty, to add new language support to elisp.
 #+LATEX_HEADER: \lstdefinelanguage{elisp}[]{lisp} {}
 #+LATEX_HEADER: \lstloadlanguages{elisp}
+
+#+PROPERTY: header-args :results silent
 * Table of Contents                                            :TOC:noexport:
 - [[#introduction][Introduction]]
 - [[#how-to-do-it][How to do it?]]

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -56,7 +56,7 @@ using elisp function ~load~ to load a org file.
 The new reader will make elisp reader enter into org mode syntax, 
 which means it will ignore all lines until it meet ~#+BEGIN_SRC elisp~.
 
-When ~#+begign_src elisp~ occur,  [[https://orgmode.org/manual/Code-block-specific-header-arguments.html#Code-block-specific-header-arguments][header arguments]] for this code block will give us
+When ~#+begin_src elisp~ occur,  [[https://orgmode.org/manual/Code-block-specific-header-arguments.html#Code-block-specific-header-arguments][header arguments]] for this code block will give us
 a chance to switch back to normal Emacs lisp reader or not.
 
 And if it switch back to normal Emacs lisp reader, the end line ~#+END_SRC~ should mean the
@@ -153,7 +153,7 @@ Argument IN: input stream."
 when read org file character by character, if current line determines as an org syntax,
 then the whole line should ignore, so there should exist such a function.
 
-Before then, let's implement an abstract method to ~read characters repeatly while a predication meet~. 
+Before then, let's implement an abstract method to ~read characters repeatly while a predicate is met~. 
 
 The ignored string return from this function 
 because it may be useful sometimes,for example when reading [[https://orgmode.org/manual/Code-block-specific-header-arguments.html#Code-block-specific-header-arguments][header arguments]] after ~#+begin_src elisp~.


### PR DESCRIPTION
- The variables `literate-elisp-begin-src-id` and `literate-elisp-end-src-id` each can now either be a string or a list of strings.
- Because of this, and a new default value for `literate-elisp-begin-src-id`, the forms `#+BEGIN_SRC elisp` and `#+BEGIN_SRC emacs-lisp` are now seen as equivalent.
- Thanks to case-insensitive matching, `#+BEGIN_SRC`/`#+END_SRC` and `#+begin_src`/`#+end_src` should now be seen as equivalent.
- There are a few other small fixes in here, which the individual commit messages explain in more detail.