### PR TITLE
‘elisp’/‘emacs-lisp’ equivalence, case insensitivity, other fixes

### DIFF
--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -234,7 +234,7 @@ Argument IN: input stream."
              ;; if it is, then switch to org mode syntax.
               (setf literate-elisp-org-code-blocks-p nil)
               nil)
-             ;; if it is not, then use original elip reader to read the following stream
+             ;; if it is not, then use original elisp reader to read the following stream
              (t (funcall literate-elisp-read in)))))))
 
 (defun literate-elisp-read-internal (&optional in)
@@ -317,7 +317,7 @@ Arguemnt ARGS: the arguments to original advice function."
 
 (defun literate-elisp-tangle-reader (&optional buf)
   "Tangling codes in one code block.
-Arguemnt BUF: source buffer."
+Argument BUF: source buffer."
   (with-output-to-string
       (with-current-buffer buf
         (when (not (string-blank-p

--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -333,11 +333,13 @@ Arguemnt BUF: source buffer."
                  (write-char ?\n)
                  (forward-line 1)))))
 
-(cl-defun literate-elisp-tangle (file &key (el-file (concat (file-name-sans-extension file) ".el"))
+(cl-defun literate-elisp-tangle (&optional (file (or org-src-source-file-name (buffer-file-name)))
+                                 &key (el-file (concat (file-name-sans-extension file) ".el"))
                                 header tail
                                 test-p)
   "Literate tangle
 Argument FILE: target file"
+  (interactive)
   (let* ((source-buffer (find-file-noselect file))
          (target-buffer (find-file-noselect el-file))
          (org-path-name (concat (file-name-base file) "." (file-name-extension file)))
@@ -356,12 +358,13 @@ Argument FILE: target file"
               "\n"))
 
     (with-current-buffer source-buffer
-      (goto-char (point-min))
-      (cl-loop for obj = (literate-elisp-read-internal source-buffer)
-               if obj
-               do (with-current-buffer target-buffer
-                    (insert obj "\n"))
-               until (eobp)))
+      (save-excursion
+        (goto-char (point-min))
+        (cl-loop for obj = (literate-elisp-read-internal source-buffer)
+                 if obj
+                 do (with-current-buffer target-buffer
+                      (insert obj "\n"))
+                 until (eobp))))
 
     (with-current-buffer target-buffer
       (when tail

--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -319,7 +319,9 @@ Arguemnt ARGS: the arguments to original advice function."
 Arguemnt BUF: source buffer."
   (with-output-to-string
       (with-current-buffer buf
-        (when (/= (point) (line-beginning-position))
+        (when (not (string-blank-p
+                    (buffer-substring (line-beginning-position)
+                                      (point))))
           ;; if reader still in last line,move it to next line.
           (forward-line 1))
 

--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -36,6 +36,7 @@
 
 
 (require 'cl-lib)
+(require 'subr-x)
 
 (defvar literate-elisp-debug-p nil)
 
@@ -327,7 +328,7 @@ Arguemnt BUF: source buffer."
 
         (loop for line = (buffer-substring-no-properties (line-beginning-position) (line-end-position))
               until (or (eobp)
-                        (string-equal (trim-string (downcase line)) "#+end_src"))
+                        (string-equal (string-trim (downcase line)) "#+end_src"))
               do (loop for c across line
                        do (write-char c))
                  (when literate-elisp-debug-p

--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -136,17 +136,20 @@ Argument IN: input stream."
   "Fix read error `invalid-read-syntax'.
 Argument IN: input stream.
 Argument BODY: body codes."
-  `(condition-case ex
-        ,@body
-      (invalid-read-syntax
-       (when literate-elisp-debug-p
-         (message "reach invalid read syntax %s at position %s"
-                  ex (literate-elisp-position in)))
-       (if (equal "#" (second ex))
-         ;; maybe this is #+end_src
-         (literate-elisp-read-after-sharpsign in)
-         ;; re-throw this signal because we don't know how to handle it.
-         (signal (car ex) (cdr err))))))
+  (declare (indent 1)
+           (debug ([&or bufferp markerp symbolp stringp "t"] body)))
+  (let ((ex (make-symbol "ex")))
+    `(condition-case ,ex
+         ,@body
+       (invalid-read-syntax
+        (when literate-elisp-debug-p
+          (message "reach invalid read syntax %s at position %s"
+                   ,ex (literate-elisp-position in)))
+        (if (equal "#" (second ,ex))
+            ;; maybe this is #+end_src
+            (literate-elisp-read-after-sharpsign in)
+          ;; re-throw this signal because we don't know how to handle it.
+          (signal (car ,ex) (cdr err)))))))
 
 (defun literate-elisp-ignore-white-space (in)
   "Skip white space characters.

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -83,8 +83,9 @@ It'll indicate whether org mode syntax or elisp mode syntax is in use.
 
 And the code block begin/end identifies:
 #+BEGIN_SRC elisp
-(defvar literate-elisp-begin-src-id "#+BEGIN_SRC elisp")
+(defvar literate-elisp-begin-src-id "#+BEGIN_SRC")
 (defvar literate-elisp-end-src-id "#+END_SRC")
+(defvar literate-elisp-lang-ids (list "elisp" "emacs-lisp"))
 #+END_SRC
 
 ** stream read functions
@@ -317,11 +318,22 @@ We have to be carefully when meeting the character ~#~ and handle different cond
 Argument IN: input stream."
   ;;     if it is not inside an elisp syntax
   (cond ((not literate-elisp-org-code-blocks-p)
-         ;; check if it is `#+begin_src elisp'
-         (if (cl-loop for i from 1 below (length literate-elisp-begin-src-id)
-                      for c1 = (aref literate-elisp-begin-src-id i)
-                      for c2 = (literate-elisp-next in)
-                      thereis (not (char-equal c1 c2)))
+         ;; check if it is `#+begin_src'…
+         (if (or (cl-loop for i from 1 below (length literate-elisp-begin-src-id)
+                          for c1 = (aref literate-elisp-begin-src-id i)
+                          for c2 = (literate-elisp-next in)
+                          with case-fold-search = t
+                          thereis (not (char-equal c1 c2)))
+                 (while (memq (literate-elisp-peek in) '(?\s ?\t))
+                   (literate-elisp-next in)) ; skip tabs and spaces, return nil
+                 ;; …followed by `elisp' or `emacs-lisp'
+                 (cl-loop with lang = ; this inner loop grabs the language specifier
+                          (cl-loop while (not (memq (literate-elisp-peek in) '(?\s ?\t ?\n)))
+                                   with rtn
+                                   collect (literate-elisp-next in) into rtn
+                                   finally return (apply 'string rtn))
+                          for id in literate-elisp-lang-ids
+                          never (string-equal (downcase lang) id)))
            ;; if it is not, continue to use org syntax and ignore this line
            (progn (literate-elisp-read-until-end-of-line in)
                   nil)
@@ -610,6 +622,32 @@ Let's write a test case for above code block.
   (should (equal literate-elisp-a-test-variable 10)))
 #+END_SRC
 
+*** test code block with lowercase block delimiters
+Some code blocks have ~#+begin_src elisp~ and ~#+end_src~ in lowercase; let's test whether ~literate-elisp~ can match it case-insensitively.
+#+begin_src elisp :load test
+(defvar literate-elisp-test-variable-2 20)
+#+end_src
+
+Let's write a test case for above code block.
+#+BEGIN_SRC elisp :load test
+(ert-deftest literate-elisp-read-lowercase-code-block ()
+  "A spec of code block with lowercase block delimiters."
+  (should (equal literate-elisp-test-variable-2 20)))
+#+END_SRC
+
+*** test code block with ~emacs-lisp~ instead of ~elisp~
+Some code blocks use ~emacs-lisp~ instead of the shortened ~elisp~ as the language specifier; let's test if ~literate-elisp-read-after-sharpsign~ matches it properly.
+#+BEGIN_SRC emacs-lisp :load test
+(defvar literate-elisp-test-variable-3 30)
+#+END_SRC
+
+Let's write a test case for the above code block.
+#+BEGIN_SRC elisp :load test
+(ert-deftest literate-elisp-read-block-with-lang-emacs-lisp ()
+  "A spec of code block with the language specifier `emacs-lisp'
+instead of `elisp'."
+  (should (equal literate-elisp-test-variable-3 30)))
+#+END_SRC
 *** test literate-elisp-read-header-arguments
 label:test-literate-elisp-read-header-arguments
 #+BEGIN_SRC elisp :load test

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -55,7 +55,7 @@ using elisp function ~load~ to load a org file.
 The new reader will make elisp reader enter into org mode syntax, 
 which means it will ignore all lines until it meet ~#+BEGIN_SRC elisp~.
 
-When ~#+begign_src elisp~ occur,  [[https://orgmode.org/manual/Code-block-specific-header-arguments.html#Code-block-specific-header-arguments][header arguments]] for this code block will give us
+When ~#+begin_src elisp~ occur,  [[https://orgmode.org/manual/Code-block-specific-header-arguments.html#Code-block-specific-header-arguments][header arguments]] for this code block will give us
 a chance to switch back to normal Emacs lisp reader or not.
 
 And if it switch back to normal Emacs lisp reader, the end line ~#+END_SRC~ should mean the
@@ -83,7 +83,7 @@ It'll indicate whether org mode syntax or elisp mode syntax is in use.
 (defvar literate-elisp-org-code-blocks-p nil)
 #+END_SRC
 
-And the code block begin/end identifies:
+And the code block begin/end identifiers:
 #+BEGIN_SRC elisp
 (defvar literate-elisp-begin-src-id "#+BEGIN_SRC")
 (defvar literate-elisp-end-src-id "#+END_SRC")
@@ -154,7 +154,7 @@ Argument IN: input stream."
 when read org file character by character, if current line determines as an org syntax,
 then the whole line should ignore, so there should exist such a function.
 
-Before then, let's implement an abstract method to ~read characters repeatly while a predication meet~. 
+Before then, let's implement an abstract method to ~read characters repeatly while a predicate is met~.
 
 The ignored string return from this function 
 because it may be useful sometimes,for example when reading [[https://orgmode.org/manual/Code-block-specific-header-arguments.html#Code-block-specific-header-arguments][header arguments]] after ~#+begin_src elisp~.
@@ -316,7 +316,7 @@ Argument IN: input stream."
 #+END_SRC
 *** how to handle when meet ~#~
 
-We have to be carefully when meeting the character ~#~ and handle different conditions that may occur:
+We have to be careful when meeting the character ~#~ and handle different conditions that may occur:
 #+BEGIN_SRC elisp
 (defun literate-elisp-read-after-sharpsign (in)
   "Read after #.
@@ -366,7 +366,7 @@ Argument IN: input stream."
              ;; if it is, then switch to org mode syntax.
               (setf literate-elisp-org-code-blocks-p nil)
               nil)
-             ;; if it is not, then use original elip reader to read the following stream
+             ;; if it is not, then use original elisp reader to read the following stream
              (t (funcall literate-elisp-read in)))))))
 #+END_SRC
 ** load/compile org file with new syntax
@@ -493,7 +493,7 @@ label:literate-elisp-tangle-reader
 #+BEGIN_SRC elisp
 (defun literate-elisp-tangle-reader (&optional buf)
   "Tangling codes in one code block.
-Arguemnt BUF: source buffer."
+Argument BUF: source buffer."
   (with-output-to-string
       (with-current-buffer buf
         (when (not (string-blank-p
@@ -621,7 +621,7 @@ and signal an error, let's test whether ~literate-elisp~ can read it gracefully.
 ;; This is a comment line to test empty code block.
 #+END_SRC
 *** test code block with prefix space.
-Some code block have white spaces before ~#+begin_src elisp~, let's test whether ~literate-elisp~ can read it normally.
+Some code blocks have white spaces before ~#+begin_src elisp~, let's test whether ~literate-elisp~ can read it normally.
   #+BEGIN_SRC elisp :load test
 (defvar literate-elisp-a-test-variable 10)
   #+END_SRC

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -495,7 +495,9 @@ label:literate-elisp-tangle-reader
 Arguemnt BUF: source buffer."
   (with-output-to-string
       (with-current-buffer buf
-        (when (/= (point) (line-beginning-position))
+        (when (not (string-blank-p
+                    (buffer-substring (line-beginning-position)
+                                      (point))))
           ;; if reader still in last line,move it to next line.
           (forward-line 1))
 
@@ -656,6 +658,21 @@ Let's write a test case for the above code block.
 instead of `elisp'."
   (should (equal literate-elisp-test-variable-3 30)))
 #+END_SRC
+
+*** test code block with indentation
+Some code blocks have indentation on the first line; let's test whether ~literate-elisp~ can read them normally.
+#+BEGIN_SRC emacs-lisp :load test
+  (defvar literate-elisp-test-variable-4 40)
+#+END_SRC
+
+Let's write a test case for the above code block.
+#+BEGIN_SRC elisp :load test
+(ert-deftest literate-elisp-read-block-with-indentation ()
+  "A spec of code block with the language specifier `emacs-lisp'
+instead of `elisp'."
+  (should (equal literate-elisp-test-variable-4 40)))
+#+END_SRC
+
 *** test literate-elisp-read-header-arguments
 label:test-literate-elisp-read-header-arguments
 #+BEGIN_SRC elisp :load test

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -238,17 +238,20 @@ Please note that the stream position is just after the character ~#~ when above 
   "Fix read error `invalid-read-syntax'.
 Argument IN: input stream.
 Argument BODY: body codes."
-  `(condition-case ex
-        ,@body
-      (invalid-read-syntax
-       (when literate-elisp-debug-p
-         (message "reach invalid read syntax %s at position %s"
-                  ex (literate-elisp-position in)))
-       (if (equal "#" (second ex))
-         ;; maybe this is #+end_src
-         (literate-elisp-read-after-sharpsign in)
-         ;; re-throw this signal because we don't know how to handle it.
-         (signal (car ex) (cdr err))))))
+  (declare (indent 1)
+           (debug ([&or bufferp markerp symbolp stringp "t"] body)))
+  (let ((ex (make-symbol "ex")))
+    `(condition-case ,ex
+         ,@body
+       (invalid-read-syntax
+        (when literate-elisp-debug-p
+          (message "reach invalid read syntax %s at position %s"
+                   ,ex (literate-elisp-position in)))
+        (if (equal "#" (second ,ex))
+            ;; maybe this is #+end_src
+            (literate-elisp-read-after-sharpsign in)
+          ;; re-throw this signal because we don't know how to handle it.
+          (signal (car ,ex) (cdr err)))))))
 #+END_SRC
 
 *** handle prefix spaces.

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -66,9 +66,10 @@ as like the original Emacs lisp reader.
 * Implementation
 ** Preparation
 
-We use common lisp macros in this library
+We use common lisp macros and subr-x functions in this library
 #+BEGIN_SRC elisp
 (require 'cl-lib)
+(require 'subr-x)
 #+END_SRC
 
 There is a debug variable to switch on/off the log messages for this library.
@@ -503,7 +504,7 @@ Arguemnt BUF: source buffer."
 
         (loop for line = (buffer-substring-no-properties (line-beginning-position) (line-end-position))
               until (or (eobp)
-                        (string-equal (trim-string (downcase line)) "#+end_src"))
+                        (string-equal (string-trim (downcase line)) "#+end_src"))
               do (loop for c across line
                        do (write-char c))
                  (when literate-elisp-debug-p

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -66,9 +66,10 @@ as like the original Emacs lisp reader.
 * Implementation
 ** Preparation
 
-We use common lisp macros and subr-x functions in this library
+We use common lisp macros, along with ob-core and subr-x functions, in this library
 #+BEGIN_SRC elisp
 (require 'cl-lib)
+(require 'ob-core)
 (require 'subr-x)
 #+END_SRC
 
@@ -88,6 +89,15 @@ And the code block begin/end identifiers:
 (defvar literate-elisp-begin-src-id "#+BEGIN_SRC")
 (defvar literate-elisp-end-src-id "#+END_SRC")
 (defvar literate-elisp-lang-ids (list "elisp" "emacs-lisp"))
+#+END_SRC
+
+This library uses ~alist-get~, which was first implemented in Emacs 25.1.
+#+BEGIN_SRC elisp
+(unless (fboundp 'alist-get)
+  (defun alist-get (key alist)
+    "A minimal definition of ‘alist-get’, for compatibility with Emacs < 25.1"
+    (let ((x (assq key alist)))
+      (when x (cdr x)))))
 #+END_SRC
 
 ** stream read functions
@@ -212,10 +222,9 @@ Let's also implement a function to read [[https://orgmode.org/manual/Code-block-
 and convert every key and value to a elisp symbol(test is here:ref:test-literate-elisp-read-header-arguments).
 #+BEGIN_SRC elisp
 (defun literate-elisp-read-header-arguments (arguments)
-  "Read org code block header arguments.
+  "Read org code block header arguments as an alist.
 Argument ARGUMENTS: a string to hold the arguments."
-  (cl-loop for token in (split-string arguments)
-        collect (intern token)))
+  (org-babel-parse-header-arguments (string-trim arguments)))
 #+END_SRC
 
 Let's define a convenient function to get load flag from the input stream. 
@@ -223,7 +232,11 @@ Let's define a convenient function to get load flag from the input stream.
 (defun literate-elisp-get-load-option (in)
   "Read load option from input stream.
 Argument IN: input stream."
-  (cl-getf (literate-elisp-read-header-arguments (literate-elisp-read-until-end-of-line in)) :load))
+  (let ((rtn (alist-get :load
+                        (literate-elisp-read-header-arguments
+                         (literate-elisp-read-until-end-of-line in)))))
+    (when (stringp rtn)
+      (intern rtn))))
 #+END_SRC
 
 
@@ -679,9 +692,27 @@ label:test-literate-elisp-read-header-arguments
 #+BEGIN_SRC elisp :load test
 (ert-deftest literate-elisp-read-header-arguments ()
   "A spec of function to read org header-arguments."
-  (should (equal (literate-elisp-read-header-arguments " :load yes") '(:load yes)))
-  (should (equal (literate-elisp-read-header-arguments " :load no  ") '(:load no)))
-  (should (equal (literate-elisp-read-header-arguments ":load yes") '(:load yes))))
+  (should (equal (literate-elisp-read-header-arguments " :load yes") '((:load . "yes"))))
+  (should (equal (literate-elisp-read-header-arguments " :load no  ") '((:load .  "no"))))
+  (should (equal (literate-elisp-read-header-arguments ":load yes") '((:load . "yes")))))
+#+END_SRC
+
+*** test the ~:load~ header argument
+#+BEGIN_SRC elisp :load test
+(ert-deftest literate-elisp-test-load-argument ()
+  (cl-flet ((test-header-args (string)
+              (let ((tempbuf (generate-new-buffer " *temp*")))
+                (unwind-protect
+                    (progn
+                      (with-current-buffer tempbuf
+                        (insert string)
+                        (goto-char 0))
+                      (literate-elisp-load-p
+                       (literate-elisp-get-load-option tempbuf)))
+                  (kill-buffer tempbuf)))))
+    (should (test-header-args " :load yes"))
+    (should-not (test-header-args " :load no  "))
+    (should (test-header-args ":load yes"))))
 #+END_SRC
 
 * References

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -1,4 +1,4 @@
-# -*- encoding:utf-8 Mode: POLY-ORG;  -*- --- 
+# -*- encoding:utf-8 Mode: POLY-ORG; org-src-preserve-indentation: t; -*- ---
 #+TITLE:  elisp literate library
 #+SubTitle: a literate programming tool to write Emacs lisp codes in org mode.
 #+OPTIONS: toc:2
@@ -6,6 +6,7 @@
 #+LATEX_HEADER: % copied from lstlang1.sty, to add new language support to elisp.
 #+LATEX_HEADER: \lstdefinelanguage{elisp}[]{lisp} {}
 #+LATEX_HEADER: \lstloadlanguages{elisp}
+#+PROPERTY: header-args :results silent
 * Table of Contents                                            :TOC:noexport:
 - [[#introduction][Introduction]]
 - [[#how-to-do-it][How to do it?]]
@@ -590,6 +591,7 @@ The head and tail lines require by [[https://github.com/melpa/melpa/blob/master/
 
 Now let's check the elisp file to meet the requirement of [[https://github.com/melpa/melpa/blob/master/CONTRIBUTING.org][MELPA]].
 #+BEGIN_SRC elisp :load no
+(require 'package-lint)
 (with-current-buffer (find-file "literate-elisp.el")
   (checkdoc)
   (package-lint-current-buffer))

--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -512,11 +512,13 @@ Arguemnt BUF: source buffer."
 
 Now we can tangle the elisp code blocks with the following codes.
 #+BEGIN_SRC elisp
-(cl-defun literate-elisp-tangle (file &key (el-file (concat (file-name-sans-extension file) ".el"))
+(cl-defun literate-elisp-tangle (&optional (file (or org-src-source-file-name (buffer-file-name)))
+                                 &key (el-file (concat (file-name-sans-extension file) ".el"))
                                 header tail
                                 test-p)
   "Literate tangle
 Argument FILE: target file"
+  (interactive)
   (let* ((source-buffer (find-file-noselect file))
          (target-buffer (find-file-noselect el-file))
          (org-path-name (concat (file-name-base file) "." (file-name-extension file)))
@@ -535,12 +537,13 @@ Argument FILE: target file"
               "\n"))
 
     (with-current-buffer source-buffer
-      (goto-char (point-min))
-      (cl-loop for obj = (literate-elisp-read-internal source-buffer)
-               if obj
-               do (with-current-buffer target-buffer
-                    (insert obj "\n"))
-               until (eobp)))
+      (save-excursion
+        (goto-char (point-min))
+        (cl-loop for obj = (literate-elisp-read-internal source-buffer)
+                 if obj
+                 do (with-current-buffer target-buffer
+                      (insert obj "\n"))
+                 until (eobp))))
 
     (with-current-buffer target-buffer
       (when tail


### PR DESCRIPTION
This is a much more clean, elegant version of [my previous pull request](#3), with the same features but without the bloat. Once again, check the commit messages for more information. I hope you like it :angel: