### PR TITLE
Support user-defined predicate arguments to :load

### DIFF
--- a/literate-elisp.org
+++ b/literate-elisp.org
@@ -210,31 +210,36 @@ Argument IN: input stream."
 #+END_SRC
 ** handle Org mode syntax
 *** code block header argument ~load~
-Emacs Lisp code in an Org file may serve a variety of
+Source blocks in a literate program can serve a variety of
 purposes—implementation, examples, testing, and so on—so we define a
 ~load~ [[https://orgmode.org/manual/Structure-of-code-blocks.html][Org code block]] [[https://orgmode.org/manual/Code-block-specific-header-arguments.html#Code-block-specific-header-arguments][header argument]] to decide whether to read them
 or not, which accepts the following values -
 - yes \\
   The current code block should be loaded.
-  This is the default value when the header argument ~load~ is not provided.
+  This is the default when the header argument ~load~ is not provided.
 - no \\
   The current code block should be ignored.
 - test \\
-  The current code block should load only when variable ~literate-elisp-test-p~ is true.
+  The current code block should load only when the variable ~literate-elisp-test-p~ is true.
+- the name of a variable or function \\
+  The code block is loaded if the value of the variable or the return value of the function is non-nil.
   #+BEGIN_SRC elisp
 (defvar literate-elisp-test-p nil)
   #+END_SRC
 
-Now let's implement above rule.
+Let's implement this behaviour.
 #+BEGIN_SRC elisp
 (defun literate-elisp-load-p (flag)
   "Return non-nil if the current elisp code block should be loaded.
-Argument FLAG: flag symbol."
-  (cl-case flag
-    ((yes nil) t)
-    (test literate-elisp-test-p)
-    (no nil)
-    (t nil)))
+FLAG is the value passed to the :load header argument, as a symbol."
+  (pcase flag
+    ((or 'yes 'nil) t)
+    ('test literate-elisp-test-p)
+    ;; these only seem to work on global definitions
+    ((pred functionp) (funcall flag))
+    ((pred boundp) bar)
+    ('no nil)
+    (_ nil)))
 #+END_SRC
 
 Let's also implement a function to read [[https://orgmode.org/manual/Code-block-specific-header-arguments.html#Code-block-specific-header-arguments][header arguments]] after
@@ -883,6 +888,9 @@ label:test-literate-elisp-read-header-arguments
 
 *** test the ~:load~ header argument
 #+BEGIN_SRC elisp :load test
+(defun literate-elisp-test-predicate-t () t)
+(defun literate-elisp-test-predicate-nil () nil)
+
 (ert-deftest literate-elisp-test-load-argument ()
   (cl-flet ((test-header-args (string)
               (let ((tempbuf (generate-new-buffer " *temp*")))
@@ -896,7 +904,9 @@ label:test-literate-elisp-read-header-arguments
                   (kill-buffer tempbuf)))))
     (should (test-header-args " :load yes"))
     (should-not (test-header-args " :load no  "))
-    (should (test-header-args ":load yes"))))
+    (should (test-header-args ":load yes"))
+    (should (test-header-args ":load literate-elisp-test-predicate-t"))
+    (should-not (test-header-args ":load literate-elisp-test-predicate-nil"))))
 #+END_SRC
 *** report error message when load incomplete code block
 #+BEGIN_SRC elisp :load test

--- a/readme.org
+++ b/readme.org
@@ -120,21 +120,22 @@ For example, This org file can be compiled with the following code.
 Now the target file ~readme.org.elc~ is ready to use.
 
 ** a new code block header argument ~load~
-There are a lot of different Emacs Lisp codes occur in one org file, some for function implementation,
-some for demo, and some for test, so an [[https://orgmode.org/manual/Structure-of-code-blocks.html][org code block]] [[https://orgmode.org/manual/Code-block-specific-header-arguments.html#Code-block-specific-header-arguments][header argument]] ~load~ to decide to
-read them or not should define, and it has the following meanings:
+Source blocks in a literate program can serve a variety of
+purposes—implementation, examples, testing, and so on—so we define a
+~load~ [[https://orgmode.org/manual/Structure-of-code-blocks.html][Org code block]] [[https://orgmode.org/manual/Code-block-specific-header-arguments.html#Code-block-specific-header-arguments][header argument]] to decide whether to read them
+or not, which accepts the following values -
 - yes \\
-  It means that current code block should load normally, 
-  it is the default mode when the header argument ~load~ is not provided.
+  The code block should be loaded normally.
+  This is the default when the header argument ~load~ is not provided.
   #+BEGIN_EXAMPLE
    ,#+BEGIN_SRC elisp :load yes
    (defun a-function-to-load ()
     (message "this function will be loaded by literate-elisp.~%"))
    ,#+END_SRC
   #+END_EXAMPLE
-  
+
 - no \\
-  It means that current code block should ignore by Emacs Lisp reader.
+  The code block should be ignored by the Emacs Lisp reader.
   #+BEGIN_EXAMPLE
    ,#+BEGIN_SRC elisp :load no
    (defun a-function-to-ignore ()
@@ -142,14 +143,15 @@ read them or not should define, and it has the following meanings:
    ,#+END_SRC
   #+END_EXAMPLE
 - test \\
-  It means that current code block should load only when variable ~literate-elisp-test-p~ is true.
+  The code block should be loaded only when the variable ~literate-elisp-test-p~ is true.
   #+BEGIN_EXAMPLE
    ,#+BEGIN_SRC elisp :load test
    (defun a-function-to-test ()
     (message "this function will be loaded by literate-elisp only if literate-elisp-test-p is true.~%"))
    ,#+END_SRC
   #+END_EXAMPLE
-
+- the name of a variable or function \\
+  The code block is loaded if the value of the variable or the return value of the function is non-nil.
 * demo routines
 ** a demo macro
 As a demo org file, we write a simple demo macro ~aif~ here.


### PR DESCRIPTION
I hope you like this patch. I'd like to use this for our [fork](https://tildegit.org/wgreenhouse/emacs-jabber) of [jabber.el](https://github.com/legoscia/emacs-jabber), which we have recently converted to a literate Org program. The idea is to conditionally load legacy features if the user requires them, without the compilation warnings which would arise from writing the conditions in Elisp.