### PR TITLE
`literate-elisp-refs--read-all-buffer-forms` now takes SYMBOLS-WITH-POS argument

### DIFF
--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -343,16 +343,20 @@ will be temporarily set to that of `literate-elisp-read-internal'
                 literate-elisp-emacs-read)))
      ,@body))
 
-(defun literate-elisp-refs--read-all-buffer-forms (orig-fun buffer symbols-with-pos)
+(cl-defun literate-elisp-refs--read-all-buffer-forms (orig-fun buffer &optional (symbols-with-pos nil swp-p))
   "Around advice to make `literate-elisp' package comparible with `elisp-refs'.
 Argument ORIG-FUN: the original function.
 Argument BUFFER: the buffer.
 Argument SYMBOLS-WITH-POS: non-nil if forms are to be read with
-`read-positioning-symbols' (Emacs 29+ only) instead of `read'."
+`read-positioning-symbols' (Emacs 29+ only) instead of `read'. (For
+compatiblity, this is only passed to the original function if it is
+specified in the function call.)"
   (literate-elisp--replace-read-maybe
       (literate-elisp--file-is-org-p
        (with-current-buffer buffer (symbol-value 'elisp-refs--path)))
-    (funcall orig-fun buffer symbols-with-pos)))
+    (if swp-p
+        (funcall orig-fun buffer symbols-with-pos)
+      (funcall orig-fun buffer))))
 
 (defun literate-elisp-refs--loaded-paths (rtn)
   "Filter return advice to prevent it from ignoring Org files.

--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -351,6 +351,11 @@ Argument SYMBOLS-WITH-POS: non-nil if forms are to be read with
 `read-positioning-symbols' (Emacs 29+ only) instead of `read'. (For
 compatiblity, this is only passed to the original function if it is
 specified in the function call.)"
+  ;; FIXME as `literate-elisp--replace-read-maybe' replaces `read'
+  ;; with `literate-elisp-read-internal' where necessary, we need to
+  ;; add a literate-elisp equivalent to the new
+  ;; `read-positioning-symbols' function, and make this advice aware
+  ;; of when to make the switch for that as well.
   (literate-elisp--replace-read-maybe
       (literate-elisp--file-is-org-p
        (with-current-buffer buffer (symbol-value 'elisp-refs--path)))

--- a/literate-elisp.el
+++ b/literate-elisp.el
@@ -343,14 +343,16 @@ will be temporarily set to that of `literate-elisp-read-internal'
                 literate-elisp-emacs-read)))
      ,@body))
 
-(defun literate-elisp-refs--read-all-buffer-forms (orig-fun buffer)
+(defun literate-elisp-refs--read-all-buffer-forms (orig-fun buffer symbols-with-pos)
   "Around advice to make `literate-elisp' package comparible with `elisp-refs'.
 Argument ORIG-FUN: the original function.
-Argument BUFFER: the buffer."
+Argument BUFFER: the buffer.
+Argument SYMBOLS-WITH-POS: non-nil if forms are to be read with
+`read-positioning-symbols' (Emacs 29+ only) instead of `read'."
   (literate-elisp--replace-read-maybe
       (literate-elisp--file-is-org-p
        (with-current-buffer buffer (symbol-value 'elisp-refs--path)))
-    (funcall orig-fun buffer)))
+    (funcall orig-fun buffer symbols-with-pos)))
 
 (defun literate-elisp-refs--loaded-paths (rtn)
   "Filter return advice to prevent it from ignoring Org files.


### PR DESCRIPTION
`elisp-refs--read-all-buffer-forms` now takes two arguments (BUFFER and SYMBOLS-WITH-POS) instead of one, so the around advice `literate-elisp-refs--read-all-buffer-forms` needs to take three arguments, now (the original function plus the two arguments it takes). This PR makes that change.

There are two problems: the first is that when writing the commit messages, I forgot that `elisp-refs` isn’t an internal Emacs package and assumed that the change to `elisp-refs--read-all-buffer-forms` happened with Emacs 28.3, so my commit message for the second commit is a bit misleading (it should say “make compatible with older versions of elisp-refs”). (If compatibility with older versions of `elisp-refs` isn’t important to you, you can omit that commit entirely; it uses some `cl-defun` magic to make it so the advice can be called with either set of arguments.)

The second problem is that the change to `elisp-refs--read-all-buffer-forms` was made to take advantage of the new function in Emacs 29, `read-positioning-symbols`. Now, if the new SYMBOLS-WITH-POS argument is non-nil, `elisp-refs--read-all-buffer-forms` will use `read-positioning-symbols` instead of `read`. Given that the purpose of the `literate-elisp-refs--read-all-buffer-forms` advice is to replace the `read` function with `literate-elisp-read-internal` temporarily when necessary, I’m assuming we’ll need a `literate-elisp` equivalent to `read-positioning-symbols` as well, and to make the `literate-elisp-refs--read-all-buffer-forms` advice aware of it. (I’m not on Emacs 29, yet, and I don’t know how `read-positioning-symbols` works, so this PR is just a quick fix so that the `literate-elisp-refs--read-all-buffer-forms` advice doesn’t return a “wrong number of arguments” error.)